### PR TITLE
feat: add a subdomain variable in the Helm values

### DIFF
--- a/apps/helloworld/templates/helloworld_hyperlinks_configmap.yaml
+++ b/apps/helloworld/templates/helloworld_hyperlinks_configmap.yaml
@@ -12,56 +12,56 @@ data:
         links: [
           {
             title: 'Argo CD',
-            url: 'https://argocd.apps.{{ .Values.cluster.name }}.{{ .Values.cluster.domain }}/',
+            url: 'https://argocd.{{ printf "%s.%s.%s" .Values.cluster.subdomain .Values.cluster.name .Values.cluster.domain  | trimPrefix "." }}/',
           },
           {{- if .Values.apps.keycloak }}
           {
             title: 'Keycloak',
-            url: 'https://keycloak.apps.{{ .Values.cluster.name }}.{{ .Values.cluster.domain }}/',
+            url: 'https://keycloak.{{ printf "%s.%s.%s" .Values.cluster.subdomain .Values.cluster.name .Values.cluster.domain  | trimPrefix "." }}/',
           },
           {{- end -}}
           {{- if .Values.apps.traefik }}
           {
             title: 'Traefik Dashboard',
-            url: 'https://traefik.apps.{{ .Values.cluster.name }}.{{ .Values.cluster.domain }}/',
+            url: 'https://traefik.{{ printf "%s.%s.%s" .Values.cluster.subdomain .Values.cluster.name .Values.cluster.domain  | trimPrefix "." }}/',
           },
           {{- end -}}
           {{- if .Values.apps.minio }}
           {
             title: 'MinIO Console',
-            url: 'https://minio.apps.{{ .Values.cluster.name }}.{{ .Values.cluster.domain }}/',
+            url: 'https://minio.{{ printf "%s.%s.%s" .Values.cluster.subdomain .Values.cluster.name .Values.cluster.domain  | trimPrefix "." }}/',
           },
           {{- end -}}
           {{- if .Values.apps.longhorn }}
           {
             title: 'Longhorn Dashboard',
-            url: 'https://longhorn.apps.{{ .Values.cluster.name }}.{{ .Values.cluster.domain }}/',
+            url: 'https://longhorn.{{ printf "%s.%s.%s" .Values.cluster.subdomain .Values.cluster.name .Values.cluster.domain  | trimPrefix "." }}/',
           },
           {{- end -}}
           {{- if .Values.apps.grafana }}
           {
             title: 'Grafana',
-            url: 'https://grafana.apps.{{ .Values.cluster.name }}.{{ .Values.cluster.domain }}/',
+            url: 'https://grafana.{{ printf "%s.%s.%s" .Values.cluster.subdomain .Values.cluster.name .Values.cluster.domain  | trimPrefix "." }}/',
           },
           {{- end -}}
           {{- if .Values.apps.prometheus }}
           {
             title: 'Prometheus',
-            url: 'https://prometheus.apps.{{ .Values.cluster.name }}.{{ .Values.cluster.domain }}/',
+            url: 'https://prometheus.{{ printf "%s.%s.%s" .Values.cluster.subdomain .Values.cluster.name .Values.cluster.domain  | trimPrefix "." }}/',
           },
           {
             title: 'Alertmanager',
-            url: 'https://alertmanager.apps.{{ .Values.cluster.name }}.{{ .Values.cluster.domain }}/',
+            url: 'https://alertmanager.{{ printf "%s.%s.%s" .Values.cluster.subdomain .Values.cluster.name .Values.cluster.domain  | trimPrefix "." }}/',
           },
           {{- end }}
           {{- if .Values.apps.thanos }}
           {
             title: 'Thanos Query',
-            url: 'https://thanos-query.apps.{{ .Values.cluster.name }}.{{ .Values.cluster.domain }}/',
+            url: 'https://thanos-query.{{ printf "%s.%s.%s" .Values.cluster.subdomain .Values.cluster.name .Values.cluster.domain  | trimPrefix "." }}/',
           },
           {
             title: 'Thanos Bucketweb',
-            url: 'https://thanos-bucketweb.apps.{{ .Values.cluster.name }}.{{ .Values.cluster.domain }}/',
+            url: 'https://thanos-bucketweb.{{ printf "%s.%s.%s" .Values.cluster.subdomain .Values.cluster.name .Values.cluster.domain  | trimPrefix "." }}/',
           },
           {{- end -}}
         ],

--- a/apps/helloworld/templates/helloworld_ingress.yaml
+++ b/apps/helloworld/templates/helloworld_ingress.yaml
@@ -12,7 +12,7 @@ metadata:
   name: {{ .Chart.Name }}-ingress
 spec:
   rules:
-  - host: helloworld.apps.{{ .Values.cluster.name }}.{{ .Values.cluster.domain }}
+  - host: "helloworld.{{ printf "%s.%s.%s" .Values.cluster.subdomain .Values.cluster.name .Values.cluster.domain | trimPrefix "." }}"
     http:
       paths:
       - backend:
@@ -24,5 +24,5 @@ spec:
         pathType: ImplementationSpecific
   tls:
   - hosts:
-    - helloworld.apps.{{ .Values.cluster.name }}.{{ .Values.cluster.domain }}
+    - "helloworld.{{ printf "%s.%s.%s" .Values.cluster.subdomain .Values.cluster.name .Values.cluster.domain | trimPrefix "." }}"
     secretName: devops-stack-helloworld-ingress-tls-cert

--- a/apps/helloworld/templates/helloworld_ingress.yaml
+++ b/apps/helloworld/templates/helloworld_ingress.yaml
@@ -22,7 +22,18 @@ spec:
               number: 8080
         path: /
         pathType: ImplementationSpecific
+  - host: "helloworld.{{ printf "%s.%s" .Values.cluster.subdomain .Values.cluster.domain | trimPrefix "." }}"
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ .Chart.Name }}-clusterip
+            port:
+              number: 8080
+        path: /
+        pathType: ImplementationSpecific
   tls:
   - hosts:
     - "helloworld.{{ printf "%s.%s.%s" .Values.cluster.subdomain .Values.cluster.name .Values.cluster.domain | trimPrefix "." }}"
+    - "helloworld.{{ printf "%s.%s" .Values.cluster.subdomain .Values.cluster.domain | trimPrefix "." }}"
     secretName: devops-stack-helloworld-ingress-tls-cert

--- a/apps/helloworld/values.yaml
+++ b/apps/helloworld/values.yaml
@@ -1,6 +1,6 @@
 ---
 cluster:
-  issuer: ca-issuer
+  issuer: selfsigned-issuer
   subdomain: "apps"
 
 image: ghcr.io/camptocamp/devops-stack-helloworld:latest

--- a/apps/helloworld/values.yaml
+++ b/apps/helloworld/values.yaml
@@ -1,6 +1,7 @@
 ---
 cluster:
   issuer: ca-issuer
+  subdomain: "apps"
 
 image: ghcr.io/camptocamp/devops-stack-helloworld:latest
 


### PR DESCRIPTION
Hello,

We have a need to use URLs without the .apps. part, in order to achieve that without introducing a breaking change we propose a new variable subdomain that defaults to apps, that way we can set it to an empty string on our side.

Tested in the helloworld application of is-internal-exo platform.