### PR TITLE
 fix: remove legacy ingress annotations

### DIFF
--- a/apps/helloworld/templates/helloworld_ingress.yaml
+++ b/apps/helloworld/templates/helloworld_ingress.yaml
@@ -5,8 +5,6 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: {{ .Values.cluster.issuer }}
-    ingress.kubernetes.io/ssl-redirect: "true"
-    kubernetes.io/ingress.allow-http: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
   name: {{ .Chart.Name }}-ingress


### PR DESCRIPTION
The SSL redirection is no longer defined by these annotations, I think this is a leftover from ancient code. The HTTP -> HTTPS redirection is handled natively by the Traefik module and is enabled by default (a variable is available to deactivate it if necessary).